### PR TITLE
[2698] Upgrade dependencies to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,21 +19,22 @@
     <java.version>21</java.version>
 
     <!-- Spring -->
-    <spring-boot-dependencies.version>3.4.1</spring-boot-dependencies.version>
+    <spring-boot-dependencies.version>3.4.8</spring-boot-dependencies.version>
 
     <!-- External -->
     <testcontainers.version>1.20.3</testcontainers.version>
 
     <!-- Internal -->
-    <structured-logging.version>3.0.20</structured-logging.version>
-    <api-sdk-java.version>6.0.21</api-sdk-java.version>
-    <private-api-sdk-java.version>4.0.235</private-api-sdk-java.version>
-    <api-sdk-manager-java-library.version>3.0.6</api-sdk-manager-java-library.version>
-    <web-security-java.version>3.1.0</web-security-java.version>
-    <java-session-handler.version>4.1.3</java-session-handler.version>
-
+    <structured-logging.version>3.0.37</structured-logging.version>
+    <api-sdk-java.version>6.4.1</api-sdk-java.version>
+    <private-api-sdk-java.version>4.0.331</private-api-sdk-java.version>
+    <api-sdk-manager-java-library.version>3.0.10</api-sdk-manager-java-library.version>
+    <web-security-java.version>3.1.6</web-security-java.version>
+    <java-session-handler.version>4.1.9</java-session-handler.version>
+    <gson.version>2.13.1</gson.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <!-- Plugin -->
-    <spring-boot-maven-plugin.version>3.4.1</spring-boot-maven-plugin.version>
+    <spring-boot-maven-plugin.version>3.4.8</spring-boot-maven-plugin.version>
     <jib-maven-plugin.version>3.4.4</jib-maven-plugin.version>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
@@ -96,11 +97,37 @@
       <groupId>uk.gov.companieshouse</groupId>
       <artifactId>structured-logging</artifactId>
       <version>${structured-logging.version}</version>
+      <exclusions>
+        <!-- Excluding to address CVE-2025-48924. commons-lang3-3.17.0 is pulled transitively-->
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- included to address CVE-2025-48924-->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang3.version}</version>
     </dependency>
     <dependency>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>api-sdk-java</artifactId>
         <version>${api-sdk-java.version}</version>
+      <exclusions>
+        <!-- Excluding to address CVE-2025-53864. gson-2.11.0 is pulled transitively-->
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- included to address CVE-2025-53864-->
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson.version}</version>
     </dependency>
     <dependency>
         <groupId>uk.gov.companieshouse</groupId>


### PR DESCRIPTION
 - Replaced hard-coded versions in dependencies with property references
 - excluded commons-lang3,gson
 - resolved CVEs CVE-2025-48734,CVE-2025-48924,CVE-2024-11407,CVE-2024-57699,CVE-2024-12798,CVE-2025-53864,CVE-2025-22235,CVE-2025-22233,CVE-2025-41232,CVE-2025-22228,CVE-2025-41234,CVE-2025-24813
 - Bumped the following dependencies
   - api-sdk-java version to 3.0.37
   - private-api-sdk-java version to 3.0.10
   - structured-logging version to 3.0.37
   - web-security-java version to 3.1.6
   - java-session-handler version to 4.1.9
   - commons-lang3 version to 3.18.0
   - gson version to 2.13.1
   - spring-boot-maven-plugin version to 3.4.8